### PR TITLE
about pombase + readme fix

### DIFF
--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -36,9 +36,9 @@ jobs:
         run: |
            cp src/pombase/index.html src/index.html   # usually copied by pombase-chado/etc/build_container.sh
            echo generating JBrowse JSON:
-           ./create_jbrowse_track_list.pl trackListTemplate.json pombase_jbrowse_track_metadata.csv /dev/null /dev/null ./minimal_jbrowse_track_list.json
-           curl -L https://raw.githubusercontent.com/pombase/pombase-config/master/website/pombase_v2_config.json > main_config.json
-           echo generating doc files:
-           ./etc/update_generated_files.sh main_config.json pombase-curation/data_files/ && node --max_old_space_size=8000 ./node_modules/@angular/cli/bin/ng build --no-progress
-           echo checking for broken links:
+           ./create_jbrowse_track_list.pl trackListTemplate.json pombase_jbrowse_track_metadata.csv /dev/null /dev/null ./minimal_jbrowse_track_list.json && \
+           curl -L https://raw.githubusercontent.com/pombase/pombase-config/master/website/pombase_v2_config.json > main_config.json && \
+           echo generating doc files: && \
+           ./etc/update_generated_files.sh main_config.json pombase-curation/data_files/ && node --max_old_space_size=8000 ./node_modules/@angular/cli/bin/ng build --no-progress && \
+           echo checking for broken links: && \
            ./etc/check_docs_broken_links.pl src/docs src/assets main_config.json

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ https://github.com/pombase/pombase-chado-json
 This is needed when the Markdown documentation changes or if the front
 page panel config changes.
 
-`./etc/update_generated_files.sh pombase-website/main_config.json pombase-curation/data_files/`
+`./etc/update_generated_files.sh pombase-config/website/pombase_v2_config.json curation/data_files/`
 
 where:
 
- - `pombase-website` is a checkout of https://github.com/pombase/website
  - `pombase-config` is a checkout of https://github.com/pombase/pombase-config
+ - `curation` is a checkout of https://github.com/pombase/curation

--- a/etc/process-markdown.pl
+++ b/etc/process-markdown.pl
@@ -590,7 +590,7 @@ sub process_path {
 
         add_to_json("$path/$page_name", $page_title, $contents);
       } else {
-        die "can't find header in: $contents\n";;
+        die "can't find header in: $path/$page_name\n";;
       }
 
       print $docs_component_fh markdown($contents, "$path/$page_name", 'html' ), "\n";

--- a/src/docs/about/collaborations.PomBase.md
+++ b/src/docs/about/collaborations.PomBase.md
@@ -1,0 +1,3 @@
+# Pombase Collaborations
+
+Coming soon.

--- a/src/docs/about/index.md
+++ b/src/docs/about/index.md
@@ -1,13 +1,28 @@
 ## About ${database_name}
 
-${database_name} is a model organism database that provides organization of
-and access to scientific data for the fission yeast
-*${genus_and_species}*. ${database_name} supports genomic sequence and
-features, genome-wide datasets and manual literature curation.
+${database_name} is the comprehensive model organism knowledgebase or the fission yeast *${genus_and_species}*, which aims to standardise, integrate, display, and disseminate biological knowledge and datasets to the wider scientific community, making a wide range of data-types from large and small-scale publications [FAIR](https://pubmed.ncbi.nlm.nih.gov/26978244/).
 
-${database_name} also provides a community hub for researchers, providing
-genome statistics, a community curation interface, news, events,
-documentation and mailing lists.
+You can use ${database_name} to:
+
+- Access and query manually **curated literature** annotations:
+  - **Gene Ontology (GO)** annotations describing the normal (evolved) roles and locations of gene products.
+  - **Phenotype** annotations linked to the alleles and genotypes that cause them.
+  - **Genetic and Physical interactions** between genes.
+  - **Protein modifications,** the gene products that add/ remove them, when in the cell cycle they occur or under which environmental conditions, .
+  - **Phylogenetic** information and **gene complementation.**
+- **Browse the genome** of *${genus_and_species}*, and access **gene sequences and features** (UTRs, exons and introns, protein sequence features).
+- Download **genome-wide datasets**.
+
+${database_name} is also a community hub for researchers providing news, events, documentation, mailing lists, genome statistics, and a community curation interface. New to the fission yeast community? Visit our [getting started page](documentation/getting-started).
+
+%%if db=PomBase
+## More about ${database_name}:
+
+  - ${database_name} promotes **community curation**, involving authors in the curation of their published research. This increases curation quality, and allows researchers to become familiar with the data organisation and supported data types. We developed [<u>Canto</u>](https://github.com/pombase/canto), a web-based curation tool to support professional and community curation that is also used by [<u>FlyBase</u>](https://flybase.org/), [<u>PHI-Base</u>](http://www.phi-base.org/) and [<u>JaponicusDB</u>](https://www.japonicusdb.org/). [Read more](community/fission-yeast-community-curation-project) about community curation.
+  - We provide over **300.000 curated standardised annotations** and our 27.000 experimentally supported GO annotations support more than 687.000 species-wide annotations in other key model species. [<u>See our stats</u>](https://curation.pombase.org/pombe/stats/annotation)
+  - We actively participate in the **development of several ontologies** to extend and improve standards that represent the knowledge produced by researchers.
+  - See all of our [ongoing collaborations](/about/collaborations).
+%%end db=PomBase
 
 %%if db=JaponicusDB
 JaponicusDB was established with support from the [Wellcome

--- a/src/docs/documentation/getting-started.md
+++ b/src/docs/documentation/getting-started.md
@@ -1,0 +1,3 @@
+# Getting started
+
+Coming soon.


### PR DESCRIPTION
I have added the new Pombase about page, and I have fixed the instructions in the readme for making the static pages locally, although I am not sure that the `Update generated docs` section is used at all at this point. I guess now this is done when the code is pushed?

I just added a small change so far, to see if you think I have done it properly, then I can continue.

Best,
Manu